### PR TITLE
Trial kludge to fix ampersands in Python reformat script

### DIFF
--- a/Scripts/reformat_xml.py
+++ b/Scripts/reformat_xml.py
@@ -13,9 +13,8 @@ for g in files:
     tree = ET.parse(g)
     root = tree.getroot()
 
-    # create new xml file
-    f = codecs.open(g, 'w','utf-8')
-    f.write('<?xml version="1.0" encoding="utf-8"?>\n\n')
+    #create list of lines for new file (kludge to solve ampersand escaping
+    lines = []
 
     # separate composer and work into two elements
     def separateComposerWork(composerAndWork):
@@ -41,38 +40,38 @@ for g in files:
                 soloist_instruments_list = str.split(soloist_instruments,";")
                 soloist_roles_list = str.split(soloist_roles,";")
                 for x in range(0,len(soloists_list)):
-                    f.write("                    <soloist>\n")
-                    f.write("                        <soloistName>%s</soloistName>\n"%fixSpaces(soloists_list[x]))
-                    f.write("                        <soloistInstrument>%s</soloistInstrument>\n"%fixSpaces(soloist_instruments_list[x]))
-                    f.write("                        <soloistRoles>%s</soloistRoles>\n"%fixSpaces(soloist_roles_list[x]))
-                    f.write("                    </soloist>\n")
+                    lines.append("                    <soloist>\n")
+                    lines.append("                        <soloistName>%s</soloistName>\n"%fixSpaces(soloists_list[x]))
+                    lines.append("                        <soloistInstrument>%s</soloistInstrument>\n"%fixSpaces(soloist_instruments_list[x]))
+                    lines.append("                        <soloistRoles>%s</soloistRoles>\n"%fixSpaces(soloist_roles_list[x]))
+                    lines.append("                    </soloist>\n")
             except:
-                f.write("                    <soloist>\n")
-                f.write("                        <soloistName>%s</soloistName>\n"%soloists)
-                f.write("                        <soloistInstrument>%s</soloistInstrument>\n"%soloist_instruments)
-                f.write("                        <soloistRoles>%s</soloistRoles>\n"%soloist_roles)
-                f.write("                    </soloist>\n")
+                lines.append("                    <soloist>\n")
+                lines.append("                        <soloistName>%s</soloistName>\n"%soloists)
+                lines.append("                        <soloistInstrument>%s</soloistInstrument>\n"%soloist_instruments)
+                lines.append("                        <soloistRoles>%s</soloistRoles>\n"%soloist_roles)
+                lines.append("                    </soloist>\n")
         else:
-            f.write("                    <soloist>\n")
-            f.write("                        <soloistName>%s</soloistName>\n"%soloists)
-            f.write("                        <soloistInstrument>%s</soloistInstrument>\n"%soloist_instruments)
-            f.write("                        <soloistRoles>%s</soloistRoles>\n"%soloist_roles)
-            f.write("                    </soloist>\n")
+            lines.append("                    <soloist>\n")
+            lines.append("                        <soloistName>%s</soloistName>\n"%soloists)
+            lines.append("                        <soloistInstrument>%s</soloistInstrument>\n"%soloist_instruments)
+            lines.append("                        <soloistRoles>%s</soloistRoles>\n"%soloist_roles)
+            lines.append("                    </soloist>\n")
 
     # reprint the unchanged entities
     def standardItems(p):
-        f.write("        <id>%s</id>\n"%p.find('id').text)
-        f.write("        <programID>%s</programID>\n"%p.find('programID').text)
-        f.write("        <orchestra>%s</orchestra>\n"%p.find('orchestra').text)
-        f.write("        <season>%s</season>\n"%p.find('season').text)
+        lines.append("        <id>%s</id>\n"%p.find('id').text)
+        lines.append("        <programID>%s</programID>\n"%p.find('programID').text)
+        lines.append("        <orchestra>%s</orchestra>\n"%p.find('orchestra').text)
+        lines.append("        <season>%s</season>\n"%p.find('season').text)
 
     # reprint unchanged concert info entities
     def concertInfo(c):
-        f.write("            <eventType>%s</eventType>\n"%c.find('eventType').text)
-        f.write("            <Location>%s</Location>\n"%c.find('Location').text)
-        f.write("            <Venue>%s</Venue>\n"%c.find('Venue').text)
-        f.write("            <Date>%s</Date>\n"%c.find('Date').text)
-        f.write("            <Time>%s</Time>\n"%c.find('Time').text)
+        lines.append("            <eventType>%s</eventType>\n"%c.find('eventType').text)
+        lines.append("            <Location>%s</Location>\n"%c.find('Location').text)
+        lines.append("            <Venue>%s</Venue>\n"%c.find('Venue').text)
+        lines.append("            <Date>%s</Date>\n"%c.find('Date').text)
+        lines.append("            <Time>%s</Time>\n"%c.find('Time').text)
 
     # reorder worksInfo children into works, each with conductor, composer, title, and soloists (if applicable)
     def sortWorksInfo(works):
@@ -83,41 +82,48 @@ for g in files:
         soloist_roles = works.findall('worksSoloistRole')
         for x in range(0,len(conductors)):
             composer_work_separated = separateComposerWork(composerAndWork[x].text)
-            f.write("            <work>\n")
+            lines.append("            <work>\n")
             if re.match(r'Intermission',composer_work_separated[0]):
-                f.write("                <interval>%s</interval>\n"%composer_work_separated[0][:-1])
+                lines.append("                <interval>%s</interval>\n"%composer_work_separated[0][:-1])
             else:
                 if composer_work_separated[0]:
-                    f.write("                <composerName>%s</composerName>\n"%composer_work_separated[0])
+                    lines.append("                <composerName>%s</composerName>\n"%composer_work_separated[0])
                 if composer_work_separated[1]:
-                    f.write("                <workTitle>%s</workTitle>\n"%composer_work_separated[1])
+                    lines.append("                <workTitle>%s</workTitle>\n"%composer_work_separated[1])
                 if conductors[x].text:
-                    f.write("                <conductorName>%s</conductorName>\n"%conductors[x].text)
+                    lines.append("                <conductorName>%s</conductorName>\n"%conductors[x].text)
                 try:
                     if soloists[x].text:
-                        f.write("                <soloists>\n")
+                        lines.append("                <soloists>\n")
                         sortSoloistInfo(soloists[x].text, soloist_instruments[x].text,soloist_roles[x].text)
-                        f.write("                </soloists>\n")
+                        lines.append("                </soloists>\n")
                 except:
                     pass
-            f.write("            </work>\n")
+            lines.append("            </work>\n")
 
     # parse xml file and write new output, per functions above
     programs = root.findall('doc')
 
-    f.write("<programs>\n")
+    lines.append("<programs>\n")
 
     for p in programs:
-        f.write("    <program>\n")
+        lines.append("    <program>\n")
         standardItems(p)
         for c in p.findall('concertInfo'):
-            f.write("        <concertInfo>\n")
+            lines.append("        <concertInfo>\n")
             concertInfo(c)
-            f.write("        </concertInfo>\n")
-        f.write("        <worksInfo>\n")
+            lines.append("        </concertInfo>\n")
+        lines.append("        <worksInfo>\n")
         sortWorksInfo(p.find('worksInfo'))
-        f.write("        </worksInfo>\n")
-        f.write("    </program>\n")
+        lines.append("        </worksInfo>\n")
+        lines.append("    </program>\n")
 
-    f.write("</programs>")
+    lines.append("</programs>")
+
+    # create new xml file
+    f = codecs.open(g, 'w','utf-8')
+    f.write('<?xml version="1.0" encoding="utf-8"?>\n\n')
+    for l in lines:
+        l = re.sub(r'&', r'&amp;', l)
+        f.write(l)
     f.close()


### PR DESCRIPTION
This is a lousy hack that attempts to restore escaping to ampersands from the original XML. I've added each line to a list, rather than writing to a file. Then loop over the list and replace '&' with '&amp;' before writing to the file. Not pretty, but should be functional, I hope.
